### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-linux-arm.yml
+++ b/.github/workflows/release-linux-arm.yml
@@ -1,4 +1,6 @@
 name: 'Release Linux Arm builds'
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/Hakanbaban53/rclone-manager/security/code-scanning/1](https://github.com/Hakanbaban53/rclone-manager/security/code-scanning/1)

The correct way to address this is to add a `permissions:` block to the workflow to explicitly specify the minimum required permissions for this build-and-upload job. Since the only GitHub-token-related usage is artifact upload (which does not require write access to repository contents or pull-requests), the minimal permission should be `contents: read`. This block should be placed at the top level of the workflow (line 2/3), so it applies to all jobs unless overridden. It is not necessary to add any imports, definitions, or other code changes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
